### PR TITLE
Hotfix/npm publish files

### DIFF
--- a/.scripts/prepublish.sh
+++ b/.scripts/prepublish.sh
@@ -9,7 +9,7 @@
 echo "=> Transpiling 'src' into ES5 ..."
 echo ""
 rm -rf ./dist
-NODE_ENV=production ./node_modules/.bin/babel --ignore tests,stories --plugins "transform-runtime" ./src --out-dir ./dist
+NODE_ENV=production ./node_modules/.bin/babel --ignore tests,stories --plugins "transform-runtime" ./src --out-dir ./dist --copy-files
 echo ""
 echo "=> Transpiling completed."
 


### PR DESCRIPTION
Simply add `--copy-files` to the prepublish script in order to add the files to NPM (not only the compiled JS)